### PR TITLE
repopulate cache on success when requesting within staleIfError

### DIFF
--- a/src/__tests__/index.spec.ts
+++ b/src/__tests__/index.spec.ts
@@ -143,6 +143,7 @@ describe("reMem", () => {
       await expect(testMemFn()).resolves.toEqual("first");
       jest.advanceTimersByTime(101);
       await expect(testMemFn()).resolves.toEqual("first");
+      // TODO verify the error is swallowed
     });
   });
 

--- a/src/__tests__/index.spec.ts
+++ b/src/__tests__/index.spec.ts
@@ -137,38 +137,82 @@ describe("reMem", () => {
       jest.useFakeTimers("modern");
     });
 
-    it("returns stale data on error after maxAge but before staleIfError ends", async () => {
-      const testError = new Error("testError");
-      const testFn = jest
-        .fn()
-        .mockResolvedValueOnce("first")
-        .mockRejectedValue(testError);
-      const testMemFn = reMem(testFn, {
-        maxAge: 100,
-        staleIfError: 500,
+    describe("after maxAge and before staleIfError ends", () => {
+      it("returns stale data on error", async () => {
+        const testError = new Error("testError");
+        const testFn = jest
+          .fn()
+          .mockResolvedValueOnce("first")
+          .mockRejectedValue(testError);
+        const testMemFn = reMem(testFn, {
+          maxAge: 100,
+          staleIfError: 500,
+        });
+        await expect(testMemFn()).resolves.toEqual("first");
+        jest.advanceTimersByTime(101);
+        await expect(testMemFn()).resolves.toEqual("first");
+        expect(testFn).toHaveBeenCalledTimes(2);
       });
-      await expect(testMemFn()).resolves.toEqual("first");
-      jest.advanceTimersByTime(101);
-      await expect(testMemFn()).resolves.toEqual("first");
-      expect(testFn).toHaveBeenCalledTimes(2);
+
+      it("repopulates cache on success", async () => {
+        const testError1 = new Error("testError 1");
+        const testError2 = new Error("testError 2");
+        const testFn = jest
+          .fn()
+          .mockResolvedValueOnce("first")
+          .mockRejectedValueOnce(testError1)
+          .mockResolvedValueOnce("second")
+          .mockRejectedValue(testError2);
+        const testMemFn = reMem(testFn, {
+          maxAge: 100,
+          staleIfError: 500,
+        });
+
+        // regular success (1 call)
+        await expect(testMemFn()).resolves.toEqual("first");
+
+        // maxAge expired, stale if error (2 calls)
+        jest.advanceTimersByTime(101);
+        await expect(testMemFn()).resolves.toEqual("first");
+
+        // maxAge expired, success again (3 calls)
+        // timers should be reset here
+        //jest.advanceTimersByTime(100);
+        await expect(testMemFn()).resolves.toEqual("second");
+
+        // here's where we test the cache is still valid
+        // maxAge, cached response
+        jest.advanceTimersByTime(50);
+        await expect(testMemFn()).resolves.toEqual("second");
+
+        // stale if error expired, error (4 calls)
+        // need to be beyond maxAge + staleIfError
+        jest.advanceTimersByTime(551);
+        await expect(testMemFn()).rejects.toEqual(testError2);
+
+        expect(testFn).toHaveBeenCalledTimes(4);
+      });
     });
 
-    it("does not return stale data on error after maxAge + staleIfError", async () => {
-      const testError = new Error("testError");
-      const testFn = jest
-        .fn()
-        .mockResolvedValueOnce("first")
-        .mockRejectedValue(testError);
-      const testMemFn = reMem(testFn, {
-        maxAge: 100,
-        staleWhileRevalidate: 500,
+    describe("after staleIfError ends", () => {
+      it("does not return stale data on error", async () => {
+        const testError = new Error("testError");
+        const testFn = jest
+          .fn()
+          .mockResolvedValueOnce("first")
+          .mockRejectedValue(testError);
+        const testMemFn = reMem(testFn, {
+          maxAge: 100,
+          staleIfError: 500,
+        });
+        await expect(testMemFn()).resolves.toEqual("first");
+        jest.advanceTimersByTime(101);
+        await expect(testMemFn()).resolves.toEqual("first");
+        jest.advanceTimersByTime(500);
+        await expect(testMemFn()).rejects.toEqual(testError);
+        expect(testFn).toHaveBeenCalledTimes(3);
       });
-      await expect(testMemFn()).resolves.toEqual("first");
-      jest.advanceTimersByTime(101);
-      await expect(testMemFn()).resolves.toEqual("first");
-      jest.advanceTimersByTime(500);
-      await expect(testMemFn()).rejects.toEqual(testError);
-      expect(testFn).toHaveBeenCalledTimes(3);
+
     });
   });
 

--- a/src/__tests__/index.spec.ts
+++ b/src/__tests__/index.spec.ts
@@ -94,7 +94,7 @@ describe("reMem", () => {
       jest.useFakeTimers("modern");
     });
 
-    it("returns stale data after maxAge but before staleWhileRevalidate ends", async () => {
+    it("returns stale data before staleWhileRevalidate ends", async () => {
       const testFn = jest
         .fn()
         .mockResolvedValueOnce("first")
@@ -110,7 +110,7 @@ describe("reMem", () => {
       await expect(testMemFn()).resolves.toEqual("second");
     });
 
-    it("does not return stale data after maxAge + staleWhileRevalidate", async () => {
+    it("does not return stale data after staleWhileRevalidate", async () => {
       const testFn = jest
         .fn()
         .mockResolvedValueOnce("first")
@@ -129,6 +129,20 @@ describe("reMem", () => {
       await expect(testMemFn()).resolves.toEqual("third");
       jest.advanceTimersByTime(601);
       await expect(testMemFn()).resolves.toEqual("fourth");
+    });
+
+    it("ignores errors on background revalidation request", async () => {
+      const testFn = jest
+        .fn()
+        .mockResolvedValueOnce("first")
+        .mockRejectedValueOnce(new Error('failed background request'));
+      const testMemFn = reMem(testFn, {
+        maxAge: 100,
+        staleWhileRevalidate: 500,
+      });
+      await expect(testMemFn()).resolves.toEqual("first");
+      jest.advanceTimersByTime(101);
+      await expect(testMemFn()).resolves.toEqual("first");
     });
   });
 

--- a/src/index.ts
+++ b/src/index.ts
@@ -135,6 +135,8 @@ function reMem<
       if (!cachePromiseRejection) {
         const cacheItem = cache.get(key);
 
+        // istanbul ignore next - infinitely cached items have no timeout
+        // see https://github.com/istanbuljs/istanbuljs/issues/526
         if (cacheItem?.timeout) {
           clearTimeout(cacheItem.timeout);
         }


### PR DESCRIPTION
Fixes #12 

Repopulate cache on staleIfError path.  Also refactor logic around staleWhileRevalidate and staleIfError and complete coverage

ps. I don't have an npm account so it'd be great to get this published/usable in some way :)